### PR TITLE
feat: GraphQL search engine, lazy history pages, rate-limit degrade

### DIFF
--- a/app/[username]/PRRetry.tsx
+++ b/app/[username]/PRRetry.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import posthog from "posthog-js";
+
+// Degraded mode: identity and the contribution graph rendered, but the PR
+// search failed (usually GitHub rate-limiting the search pool). Poll the
+// prs route with backoff; the first success warms the server cache, so a
+// refresh re-renders the full page.
+const BASE_DELAY_MS = 8000;
+const MAX_DELAY_MS = 30000;
+
+export default function PRRetry({
+  username,
+  reason,
+}: {
+  username: string;
+  reason: string;
+}) {
+  const router = useRouter();
+  const [attempt, setAttempt] = React.useState(0);
+
+  React.useEffect(() => {
+    posthog.capture("profile_degraded", { profile: username, reason });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [username]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    const delay =
+      Math.min(BASE_DELAY_MS * (attempt + 1), MAX_DELAY_MS) +
+      Math.random() * 2000;
+    const timer = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/${username}/prs`);
+        if (cancelled) return;
+        if (res.ok) {
+          posthog.capture("profile_degraded_recovered", {
+            profile: username,
+            attempts: attempt + 1,
+          });
+          router.refresh();
+          return;
+        }
+      } catch {
+        // network hiccup — fall through to the next attempt
+      }
+      if (!cancelled) setAttempt((a) => a + 1);
+    }, delay);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [attempt, username, router]);
+
+  return (
+    <div className="relative mt-10">
+      <span
+        aria-hidden
+        className="rail-line absolute bottom-2 left-3 top-0 w-[2px] rounded-full bg-zinc-200 dark:bg-zinc-800"
+      />
+      <p className="font-mono relative pl-10 text-sm text-zinc-500 dark:text-zinc-400">
+        {reason === "rate_limited"
+          ? "GitHub is rate-limiting us right now — the pull requests will load automatically in a moment."
+          : "GitHub isn't answering right now — retrying automatically."}
+      </p>
+    </div>
+  );
+}

--- a/app/[username]/PRSections.tsx
+++ b/app/[username]/PRSections.tsx
@@ -24,6 +24,9 @@ interface PRSectionsProps {
   totalCount: number;
   since: number | null;
   excludedRepoNames: string[];
+  /** Cursor to resume loading deeper history pages; null when complete. */
+  endCursor: string | null;
+  hasNext: boolean;
 }
 
 export default function PRSections({
@@ -34,10 +37,19 @@ export default function PRSections({
   totalCount,
   since,
   excludedRepoNames,
+  endCursor,
+  hasNext,
 }: PRSectionsProps) {
-  // The full history is already here; the window limits DOM size, not data.
+  // The server sends page 1 (100 PRs); the window limits DOM size and the
+  // sentinel pulls deeper data pages through /api/[username]/prs on scroll.
   const [visible, setVisible] = React.useState(INITIAL_WINDOW);
   const sentinelRef = React.useRef<HTMLLIElement>(null);
+  const [deeperPRs, setDeeperPRs] = React.useState<ProfilePR[]>([]);
+  const [paging, setPaging] = React.useState({ cursor: endCursor, hasNext });
+  const loadingRef = React.useRef(false);
+  // The observer callback can fire with a stale closure between a fetch
+  // resolving and the re-render; never fetch the same cursor twice.
+  const fetchedCursorsRef = React.useRef(new Set<string>());
 
   // Optimistic curation: the card moves the moment the star is pressed;
   // useOptimistic reverts to the server-derived lists if the action fails,
@@ -65,7 +77,7 @@ export default function PRSections({
     startTransition(async () => {
       addMove({ id: pr.id, featured: makeFeatured });
       const result = await toggleFeaturedAction({
-        prId: pr.id.toString(),
+        prUrl: pr.html_url,
         username,
       });
       setErrors((prev) => {
@@ -79,7 +91,7 @@ export default function PRSections({
 
   const serverFeatured = [
     ...featuredPRs.filter((p) => moves[p.id] !== false),
-    ...nonFeaturedPRs.filter((p) => moves[p.id] === true),
+    ...[...nonFeaturedPRs, ...deeperPRs].filter((p) => moves[p.id] === true),
   ];
 
   // Drag order lives locally until the action confirms; revalidated props
@@ -111,10 +123,13 @@ export default function PRSections({
     const ids = orderRef.current;
     if (!ids) return;
     posthog.capture("featured_reordered", { profile: username });
+    const byId = new Map(displayFeatured.map((p) => [p.id, p.html_url]));
     startTransition(async () => {
       const result = await reorderFeaturedAction({
         username,
-        orderedIds: ids.map(String),
+        orderedUrls: ids
+          .map((id) => byId.get(id))
+          .filter((url): url is string => Boolean(url)),
       });
       if (result?.error) {
         setOrderOverride(null);
@@ -124,14 +139,52 @@ export default function PRSections({
   };
 
   const canReorder = isOwner && curating && displayFeatured.length > 1;
+  const seenUrls = new Set(
+    [...featuredPRs, ...nonFeaturedPRs].map((p) => p.html_url)
+  );
+  const freshDeeper = deeperPRs.filter(
+    (p) => !seenUrls.has(p.html_url) && !excludedRepoNames.includes(p.repo)
+  );
   const displayRest = [
     ...nonFeaturedPRs.filter((p) => moves[p.id] !== true),
+    ...freshDeeper.filter((p) => moves[p.id] !== true),
     ...featuredPRs.filter((p) => moves[p.id] === false),
   ].sort(
     (a, b) => new Date(b.merged_at).getTime() - new Date(a.merged_at).getTime()
   );
 
-  const hasMore = visible < displayRest.length;
+  const hasMore = visible < displayRest.length || paging.hasNext;
+
+  const loadDeeperPage = React.useCallback(async () => {
+    if (!paging.hasNext || !paging.cursor || loadingRef.current) return;
+    if (fetchedCursorsRef.current.has(paging.cursor)) return;
+    loadingRef.current = true;
+    fetchedCursorsRef.current.add(paging.cursor);
+    try {
+      const params = new URLSearchParams({ cursor: paging.cursor });
+      const res = await fetch(`/api/${username}/prs?${params}`);
+      if (!res.ok) {
+        fetchedCursorsRef.current.delete(paging.cursor);
+        return; // sentinel stays; the next intersection retries
+      }
+      const page: {
+        items: ProfilePR[];
+        endCursor: string | null;
+        hasNext: boolean;
+      } = await res.json();
+      setPaging({ cursor: page.endCursor, hasNext: page.hasNext });
+      setDeeperPRs((prev) => {
+        const seen = new Set(prev.map((p) => p.html_url));
+        return [...prev, ...page.items.filter((p) => !seen.has(p.html_url))];
+      });
+      posthog.capture("history_page_loaded", { profile: username });
+    } catch {
+      fetchedCursorsRef.current.delete(paging.cursor);
+      // transient network failure — retry on the next intersection
+    } finally {
+      loadingRef.current = false;
+    }
+  }, [username, paging.cursor, paging.hasNext]);
 
   // One product event per profile view, with the numbers that matter.
   React.useEffect(() => {
@@ -149,29 +202,34 @@ export default function PRSections({
     if (!el || !hasMore) return;
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries[0].isIntersecting) {
-          setVisible((v) => {
-            posthog.capture("list_extended", {
-              profile: username,
-              shown_after: v + WINDOW_STEP,
-            });
-            return v + WINDOW_STEP;
+        if (!entries[0].isIntersecting) return;
+        setVisible((v) => {
+          posthog.capture("list_extended", {
+            profile: username,
+            shown_after: v + WINDOW_STEP,
           });
-        }
+          return v + WINDOW_STEP;
+        });
+        // Keep the data ahead of the window.
+        if (visible + WINDOW_STEP >= displayRest.length) void loadDeeperPage();
       },
       { rootMargin: "600px" }
     );
     observer.observe(el);
     return () => observer.disconnect();
-  }, [hasMore]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasMore, visible, displayRest.length, loadDeeperPage]);
 
   const shownRest = displayRest.slice(0, visible);
   const knownRepos = [
-    ...new Set([...featuredPRs, ...nonFeaturedPRs].map((p) => p.repo)),
+    ...new Set(
+      [...featuredPRs, ...nonFeaturedPRs, ...freshDeeper].map((p) => p.repo)
+    ),
   ];
-  const allLoaded = [...featuredPRs, ...nonFeaturedPRs];
-  // The search API stops at 1000 results; beyond that the numbers are floors.
-  const capped = totalCount > 1000;
+  const allLoaded = [...featuredPRs, ...nonFeaturedPRs, ...freshDeeper];
+  // Floors, not exact: search caps at 1000 results, and repo variety can
+  // only grow while deeper pages remain unloaded.
+  const capped = totalCount > 1000 || paging.hasNext;
 
   return (
     <>

--- a/app/[username]/PRSections.tsx
+++ b/app/[username]/PRSections.tsx
@@ -27,6 +27,8 @@ interface PRSectionsProps {
   /** Cursor to resume loading deeper history pages; null when complete. */
   endCursor: string | null;
   hasNext: boolean;
+  /** Exact full repo list (incl. excluded); null = unknown, show a floor. */
+  repoNames: string[] | null;
 }
 
 export default function PRSections({
@@ -39,6 +41,7 @@ export default function PRSections({
   excludedRepoNames,
   endCursor,
   hasNext,
+  repoNames,
 }: PRSectionsProps) {
   // The server sends page 1 (100 PRs); the window limits DOM size and the
   // sentinel pulls deeper data pages through /api/[username]/prs on scroll.
@@ -221,15 +224,18 @@ export default function PRSections({
   }, [hasMore, visible, displayRest.length, loadDeeperPage]);
 
   const shownRest = displayRest.slice(0, visible);
-  const knownRepos = [
-    ...new Set(
-      [...featuredPRs, ...nonFeaturedPRs, ...freshDeeper].map((p) => p.repo)
-    ),
-  ];
+  // Exact when the repo breakdown resolved; loaded-derived floor otherwise.
+  const knownRepos = repoNames
+    ? repoNames.filter((r) => !excludedRepoNames.includes(r))
+    : [
+        ...new Set(
+          [...featuredPRs, ...nonFeaturedPRs, ...freshDeeper].map((p) => p.repo)
+        ),
+      ];
   const allLoaded = [...featuredPRs, ...nonFeaturedPRs, ...freshDeeper];
-  // Floors, not exact: search caps at 1000 results, and repo variety can
-  // only grow while deeper pages remain unloaded.
-  const capped = totalCount > 1000 || paging.hasNext;
+  // Search caps at 1000 results; without the breakdown the repo list is
+  // also a floor while deeper pages remain unloaded.
+  const capped = totalCount > 1000 || (!repoNames && paging.hasNext);
 
   return (
     <>

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -5,6 +5,7 @@ import { getProfileData } from "~/lib/profile";
 import ContributionGraph from "~/components/custom/ContributionGraph";
 import ShareProfile from "~/components/custom/ShareProfile";
 import TrackEvent from "~/components/custom/TrackEvent";
+import PRRetry from "./PRRetry";
 import PRSections from "./PRSections";
 
 async function getDomain() {
@@ -61,8 +62,8 @@ export default async function ProfilePage({
   const {
     notFound,
     loadError,
+    prsDegraded,
     errorReason,
-    errorStatus,
     userData,
     items,
     totalCount,
@@ -71,6 +72,8 @@ export default async function ProfilePage({
     featuredPRs,
     nonFeaturedPRs,
     excludedGitHubRepos,
+    endCursor,
+    hasNext,
     ownerRowId,
   } = await getProfileData(username);
 
@@ -92,7 +95,6 @@ export default async function ProfilePage({
             profile: username,
             type: "load_error",
             reason: errorReason ?? "error",
-            status: errorStatus ?? 0,
           }}
         />
         <p className="font-mono text-sm text-zinc-500 dark:text-zinc-400">
@@ -193,7 +195,9 @@ export default async function ProfilePage({
         </a>
       ) : null}
 
-      {items.length ? (
+      {prsDegraded ? (
+        <PRRetry username={username} reason={errorReason ?? "error"} />
+      ) : items.length ? (
         <PRSections
           featuredPRs={featuredPRs}
           nonFeaturedPRs={nonFeaturedPRs}
@@ -202,10 +206,12 @@ export default async function ProfilePage({
           totalCount={totalCount}
           since={sinceYear}
           excludedRepoNames={excludedGitHubRepos}
+          endCursor={endCursor}
+          hasNext={hasNext}
         />
       ) : (
         <p className="font-mono mt-10 text-sm text-zinc-500 dark:text-zinc-400">
-          No public merged PRs in the last three years.
+          No public merged PRs yet.
           {isOwner ? " Go make some! 🚀" : ""}
         </p>
       )}

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -74,6 +74,7 @@ export default async function ProfilePage({
     excludedGitHubRepos,
     endCursor,
     hasNext,
+    repoNames,
     ownerRowId,
   } = await getProfileData(username);
 
@@ -208,6 +209,7 @@ export default async function ProfilePage({
           excludedRepoNames={excludedGitHubRepos}
           endCursor={endCursor}
           hasNext={hasNext}
+          repoNames={repoNames}
         />
       ) : (
         <p className="font-mono mt-10 text-sm text-zinc-500 dark:text-zinc-400">

--- a/app/api/[username]/og/route.tsx
+++ b/app/api/[username]/og/route.tsx
@@ -1,5 +1,9 @@
 import { ImageResponse } from "next/og";
-import { getGitHubUserData, searchMergedPRs } from "~/lib/github";
+import {
+  getDeepRepoNames,
+  getGitHubUserData,
+  searchMergedPRs,
+} from "~/lib/github";
 import type { GithubUser } from "~/types/shared";
 
 const INK = "#18181B";
@@ -36,9 +40,16 @@ export async function GET(
   ]);
 
   const total = prs.totalCount;
-  const repoCount = new Set(prs.items.map((i) => i.repo)).size;
-  // Page 1 sees at most 100 PRs; deeper history can only add repos.
-  const repos = prs.hasNext && repoCount ? `${repoCount}+` : String(repoCount);
+  const page1Repos = [...new Set(prs.items.map((i) => i.repo))];
+  const deep = prs.hasNext ? await getDeepRepoNames(username, total) : [];
+  const repoCount = deep
+    ? new Set([...page1Repos, ...deep]).size
+    : page1Repos.length;
+  // Exact unless the breakdown failed or the 1000-result cap hides history.
+  const repos =
+    (deep === null || total > 1000) && repoCount
+      ? `${repoCount}+`
+      : String(repoCount);
   const since = prs.sinceYear;
   const name = (user.data as GithubUser | null)?.name ?? username;
 

--- a/app/api/[username]/og/route.tsx
+++ b/app/api/[username]/og/route.tsx
@@ -1,9 +1,5 @@
 import { ImageResponse } from "next/og";
-import {
-  getAllMergedPRs,
-  getFirstMergedYear,
-  getGitHubUserData,
-} from "~/lib/github";
+import { getGitHubUserData, searchMergedPRs } from "~/lib/github";
 import type { GithubUser } from "~/types/shared";
 
 const INK = "#18181B";
@@ -27,24 +23,23 @@ export async function GET(
 
   // Font files ride the same 1h data cache as the PR history; after one
   // profile render this whole route serves from cache.
-  const [geistSemiBold, geistMono, prs, user, since] = await Promise.all([
+  const [geistSemiBold, geistMono, prs, user] = await Promise.all([
     fetch(`${domain}/assets/Geist-SemiBold.ttf`, { cache: "force-cache" }).then(
       (r) => r.arrayBuffer()
     ),
     fetch(`${domain}/assets/GeistMono-Regular.ttf`, {
       cache: "force-cache",
     }).then((r) => r.arrayBuffer()),
-    getAllMergedPRs(username),
+    // One batched GraphQL request: page 1, total, and the since-year probe.
+    searchMergedPRs(username),
     getGitHubUserData(username),
-    // Exact first-merged-PR year even past the 1000-result search cap.
-    getFirstMergedYear(username),
   ]);
 
-  const items = prs.data?.items ?? [];
-  const total = prs.data?.total_count ?? 0;
-  const repos = new Set(
-    items.map((i) => i.repository_url.slice(29))
-  ).size;
+  const total = prs.totalCount;
+  const repoCount = new Set(prs.items.map((i) => i.repo)).size;
+  // Page 1 sees at most 100 PRs; deeper history can only add repos.
+  const repos = prs.hasNext && repoCount ? `${repoCount}+` : String(repoCount);
+  const since = prs.sinceYear;
   const name = (user.data as GithubUser | null)?.name ?? username;
 
   // Satori needs single text children.
@@ -53,7 +48,7 @@ export async function GET(
 
   const stats: Array<[string, string]> = [
     [String(total), "merged PRs"],
-    ...(repos ? [[String(repos), "repositories"] as [string, string]] : []),
+    ...(repoCount ? [[repos, "repositories"] as [string, string]] : []),
     ...(since ? [[String(since), "since"] as [string, string]] : []),
   ];
 

--- a/app/api/[username]/prs/route.ts
+++ b/app/api/[username]/prs/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { searchMergedPRs } from "~/lib/github";
+
+// Deeper history pages for the profile's infinite scroll. The underlying
+// GraphQL page is server-cached for an hour; the CDN caches the JSON too,
+// so a hot profile costs GitHub nothing as visitors scroll.
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ username: string }> }
+) {
+  const { username } = await params;
+  if (!/^[a-zA-Z0-9-]{1,39}$/.test(username)) {
+    return NextResponse.json({ error: "invalid username" }, { status: 400 });
+  }
+  const cursor = new URL(request.url).searchParams.get("cursor");
+
+  const page = await searchMergedPRs(username, cursor);
+  if (page.error) {
+    return NextResponse.json(
+      { error: "unavailable", reason: page.reason ?? "error" },
+      { status: page.reason === "rate_limited" ? 429 : 502 }
+    );
+  }
+
+  return NextResponse.json(
+    { items: page.items, endCursor: page.endCursor, hasNext: page.hasNext },
+    {
+      headers: {
+        "cache-control": "public, s-maxage=3600, stale-while-revalidate=86400",
+      },
+    }
+  );
+}

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,4 +1,9 @@
-import type { GitHubIssuesResponse, GitHubUser } from "~/types/shared";
+import { unstable_cache } from "next/cache";
+import type {
+  GitHubIssuesResponse,
+  GitHubUser,
+  ProfilePR,
+} from "~/types/shared";
 import {
   type GithubFailureReason,
   reportGithubFailure,
@@ -128,64 +133,231 @@ export const getPRsFromGithubAPI = async (filter: PRFilter) => {
 };
 
 /**
- * Fetch the author's complete merged-PR history (search API caps at 1000).
- * Page 1 reveals total_count; remaining pages fetch in parallel. Each page
- * is cached on the Next data layer for an hour, so this costs at most
- * ceil(total/100) GitHub calls per profile per hour.
+ * One page of an author's merged-PR history, oldest-visible-first cursor.
+ * GraphQL is the primary engine: the search bills GraphQL points (5000/hr)
+ * instead of REST search's 30 req/min, and the first page batches the
+ * since-year probe into the same request (~1 point total). REST search
+ * remains the tokenless fallback, with cursors encoded as "p:<page>".
  */
-export const getAllMergedPRs = async (author: string) => {
-  const first = await getPRsFromGithubAPI({
-    author,
-    limit: 100,
-    page: 1,
-    tag: "history",
-  });
-  if (first.error || !first.data) {
-    return {
-      data: null,
-      error: first.error,
-      status: first.status,
-      reason: first.reason,
-    };
-  }
+export interface PRPage {
+  items: ProfilePR[];
+  totalCount: number;
+  endCursor: string | null;
+  hasNext: boolean;
+  /** Exact first-merged year; resolved on first pages only. */
+  sinceYear: number | null;
+}
 
-  const total = first.data.total_count;
-  const pages = Math.min(Math.ceil(total / 100), 10);
-  if (pages <= 1) {
-    return { data: first.data, error: null, status: first.status };
-  }
-
-  const rest = await Promise.all(
-    Array.from({ length: pages - 1 }, (_, i) =>
-      getPRsFromGithubAPI({ author, limit: 100, page: i + 2, tag: "history" })
-    )
-  );
-  const items = [
-    ...first.data.items,
-    ...rest.flatMap((r) => r.data?.items ?? []),
-  ];
-  return {
-    data: { ...first.data, items },
-    error: null,
-    status: first.status,
-  };
+export type PRPageResult = PRPage & {
+  error: unknown | null;
+  reason?: GithubFailureReason;
 };
 
-/**
- * Year of the author's first merged PR. One ascending-sorted search with
- * per_page=1 — exact even when the career exceeds the 1000-result cap that
- * bounds getAllMergedPRs.
- */
-export const getFirstMergedYear = async (author: string) => {
+const EMPTY_PAGE: PRPage = {
+  items: [],
+  totalCount: 0,
+  endCursor: null,
+  hasNext: false,
+  sinceYear: null,
+};
+
+class GithubApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly rateLimitRemaining: string | null,
+    public readonly rateLimitReset: string | null,
+    public readonly retryAfter: string | null
+  ) {
+    super(message);
+    this.name = "GithubApiError";
+  }
+}
+
+const PR_NODE_FIELDS = `... on PullRequest {
+  databaseId
+  title
+  url
+  mergedAt
+  comments { totalCount }
+  reactions { totalCount }
+  repository { nameWithOwner }
+}`;
+
+interface GraphQLPRNode {
+  databaseId: number;
+  title: string;
+  url: string;
+  mergedAt: string;
+  comments: { totalCount: number };
+  reactions: { totalCount: number };
+  repository: { nameWithOwner: string };
+}
+
+function nodeToProfilePR(node: GraphQLPRNode): ProfilePR {
+  return {
+    id: node.databaseId,
+    title: node.title,
+    html_url: node.url,
+    repo: node.repository.nameWithOwner,
+    merged_at: node.mergedAt,
+    reactions_count: node.reactions.totalCount,
+    comments: node.comments.totalCount,
+  };
+}
+
+// Throws GithubApiError so unstable_cache never caches a failed page.
+async function rawGraphQLSearchPage(
+  author: string,
+  cursor: string | null
+): Promise<PRPage> {
+  const q = `author:${author} type:pr is:public is:merged sort:created-desc`;
+  const probeQ = `author:${author} type:pr is:public is:merged sort:created-asc`;
+  const firstPage = cursor === null;
+
+  const query = firstPage
+    ? `query($q: String!, $probeQ: String!) {
+        search(query: $q, type: ISSUE, first: 100) {
+          issueCount
+          pageInfo { endCursor hasNextPage }
+          nodes { ${PR_NODE_FIELDS} }
+        }
+        probe: search(query: $probeQ, type: ISSUE, first: 1) {
+          nodes { ... on PullRequest { mergedAt } }
+        }
+      }`
+    : `query($q: String!, $cursor: String!) {
+        search(query: $q, type: ISSUE, first: 100, after: $cursor) {
+          issueCount
+          pageInfo { endCursor hasNextPage }
+          nodes { ${PR_NODE_FIELDS} }
+        }
+      }`;
+
+  const response = await fetch("https://api.github.com/graphql", {
+    method: "POST",
+    headers: githubHeaders(),
+    body: JSON.stringify({
+      query,
+      variables: firstPage ? { q, probeQ } : { q, cursor },
+    }),
+    cache: "no-store",
+    signal: AbortSignal.timeout(8000),
+  });
+  const json = await response.json();
+  const search = json?.data?.search;
+  if (!response.ok || json.errors || !search) {
+    throw new GithubApiError(
+      json?.errors?.[0]?.message ?? json?.message ?? `GitHub HTTP ${response.status}`,
+      response.status,
+      response.headers.get("x-ratelimit-remaining"),
+      response.headers.get("x-ratelimit-reset"),
+      response.headers.get("retry-after")
+    );
+  }
+
+  const probeMergedAt: string | undefined =
+    json.data.probe?.nodes?.[0]?.mergedAt;
+  return {
+    items: (search.nodes as GraphQLPRNode[])
+      .filter((n) => n && n.databaseId)
+      .map(nodeToProfilePR),
+    totalCount: search.issueCount,
+    endCursor: search.pageInfo.hasNextPage ? search.pageInfo.endCursor : null,
+    hasNext: search.pageInfo.hasNextPage,
+    sinceYear: probeMergedAt ? new Date(probeMergedAt).getFullYear() : null,
+  };
+}
+
+const cachedGraphQLSearchPage = unstable_cache(
+  rawGraphQLSearchPage,
+  ["gh-search-page"],
+  { revalidate: 3600 }
+);
+
+function restItemToProfilePR(
+  item: GitHubIssuesResponse["items"][number]
+): ProfilePR {
+  return {
+    id: item.id,
+    title: item.title,
+    html_url: item.html_url,
+    repo: item.repository_url.slice(29),
+    merged_at: item.pull_request.merged_at,
+    reactions_count: item.reactions.total_count,
+    comments: item.comments,
+  };
+}
+
+// Tokenless fallback: GraphQL requires auth, REST search allows 10 req/min
+// unauthenticated. Dev-only in practice; every real deployment has a token.
+async function restSearchPage(
+  author: string,
+  cursor: string | null
+): Promise<PRPageResult> {
+  const page = cursor ? Number(cursor.slice(2)) : 1;
   const res = await getPRsFromGithubAPI({
     author,
-    limit: 1,
-    page: 1,
-    order: "asc",
-    tag: "since-year",
+    limit: 100,
+    page,
+    tag: "history",
   });
-  const first = res.data?.items?.[0];
-  return first ? new Date(first.pull_request.merged_at).getFullYear() : null;
+  if (res.error || !res.data) {
+    return { ...EMPTY_PAGE, error: res.error, reason: res.reason };
+  }
+  const total = res.data.total_count;
+  const loadedThrough = page * 100;
+  const hasNext = loadedThrough < Math.min(total, 1000);
+  let sinceYear: number | null = null;
+  if (page === 1) {
+    if (total <= 100 && res.data.items.length) {
+      sinceYear = new Date(
+        res.data.items[res.data.items.length - 1].pull_request.merged_at
+      ).getFullYear();
+    } else {
+      const probe = await getPRsFromGithubAPI({
+        author,
+        limit: 1,
+        page: 1,
+        order: "asc",
+        tag: "since-year",
+      });
+      const first = probe.data?.items?.[0];
+      sinceYear = first
+        ? new Date(first.pull_request.merged_at).getFullYear()
+        : null;
+    }
+  }
+  return {
+    items: res.data.items.map(restItemToProfilePR),
+    totalCount: total,
+    endCursor: hasNext ? `p:${page + 1}` : null,
+    hasNext,
+    sinceYear,
+    error: null,
+  };
+}
+
+export const searchMergedPRs = async (
+  author: string,
+  cursor: string | null = null
+): Promise<PRPageResult> => {
+  if (!process.env.GITHUB_TOKEN) return restSearchPage(author, cursor);
+  try {
+    const page = await cachedGraphQLSearchPage(author, cursor);
+    return { ...page, error: null };
+  } catch (error) {
+    const apiError = error instanceof GithubApiError ? error : null;
+    const reason = reportGithubFailure({
+      source: cursor ? "graphql-search:cursor" : "graphql-search:p1",
+      status: apiError?.status ?? 0,
+      message: error instanceof Error ? error.message : String(error),
+      rateLimitRemaining: apiError?.rateLimitRemaining,
+      rateLimitReset: apiError?.rateLimitReset,
+      retryAfter: apiError?.retryAfter,
+    });
+    return { ...EMPTY_PAGE, error, reason };
+  }
 };
 
 export const getGitHubUserData = async (username: string) => {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -496,16 +496,10 @@ const LEVELS: Record<string, number> = {
   FOURTH_QUARTILE: 4,
 };
 
-/**
- * First-party contribution calendar via the GraphQL API (replaces the
- * ghchart.rshah.org hotlink). Requires GITHUB_TOKEN; returns null without
- * it so the profile simply omits the graph.
- */
-export const getContributionCalendar = async (
+// Throws so unstable_cache never stores a failed calendar.
+async function rawContributionCalendar(
   username: string
-): Promise<ContributionCalendar | null> => {
-  if (!process.env.GITHUB_TOKEN) return null;
-
+): Promise<ContributionCalendar | null> {
   const query = `query($login: String!) {
     user(login: $login) {
       contributionsCollection {
@@ -519,54 +513,80 @@ export const getContributionCalendar = async (
     }
   }`;
 
+  const response = await fetch("https://api.github.com/graphql", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ query, variables: { login: username } }),
+    // POST fetches never enter the Next data cache; unstable_cache below
+    // is the real cache for this call.
+    cache: "no-store",
+    signal: AbortSignal.timeout(8000),
+  });
+  const json = await response.json();
+  const calendar =
+    json?.data?.user?.contributionsCollection?.contributionCalendar;
+  if (!calendar) {
+    // "no such user" is a valid, cacheable answer, not a failure.
+    if (response.ok && json?.errors?.[0]?.type === "NOT_FOUND") return null;
+    throw new GithubApiError(
+      json?.errors?.[0]?.message ?? json?.message ?? `GitHub HTTP ${response.status}`,
+      response.status,
+      response.headers.get("x-ratelimit-remaining"),
+      response.headers.get("x-ratelimit-reset"),
+      response.headers.get("retry-after")
+    );
+  }
+  return {
+    total: calendar.totalContributions,
+    weeks: calendar.weeks.map(
+      (week: {
+        contributionDays: {
+          contributionLevel: string;
+          contributionCount: number;
+          date: string;
+        }[];
+      }) =>
+        week.contributionDays.map(
+          (day) =>
+            [
+              LEVELS[day.contributionLevel] ?? 0,
+              day.contributionCount,
+              day.date,
+            ] as [number, number, string]
+        )
+    ),
+  };
+}
+
+const cachedContributionCalendar = unstable_cache(
+  rawContributionCalendar,
+  ["gh-contribution-calendar"],
+  { revalidate: 3600 }
+);
+
+/**
+ * First-party contribution calendar via the GraphQL API. Requires
+ * GITHUB_TOKEN; returns null without it (or on failure) so the profile
+ * simply omits the graph.
+ */
+export const getContributionCalendar = async (
+  username: string
+): Promise<ContributionCalendar | null> => {
+  if (!process.env.GITHUB_TOKEN) return null;
   try {
-    const response = await fetch("https://api.github.com/graphql", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({ query, variables: { login: username } }),
-      next: { revalidate: 3600 },
-      signal: AbortSignal.timeout(8000),
-    });
-    const json = await response.json();
-    const calendar =
-      json?.data?.user?.contributionsCollection?.contributionCalendar;
-    if (!calendar) {
-      reportGithubFailure({
-        source: "graphql",
-        status: response.status,
-        message: json?.errors?.[0]?.message ?? json?.message,
-        headers: response.headers,
-      });
-      return null;
-    }
-    return {
-      total: calendar.totalContributions,
-      weeks: calendar.weeks.map(
-        (week: {
-          contributionDays: {
-            contributionLevel: string;
-            contributionCount: number;
-            date: string;
-          }[];
-        }) =>
-          week.contributionDays.map(
-            (day) =>
-              [
-                LEVELS[day.contributionLevel] ?? 0,
-                day.contributionCount,
-                day.date,
-              ] as [number, number, string]
-          )
-      ),
-    };
+    return await cachedContributionCalendar(username);
   } catch (error) {
+    const apiError = error instanceof GithubApiError ? error : null;
     reportGithubFailure({
       source: "graphql",
-      status: 0,
+      status: apiError?.status ?? 0,
       message: error instanceof Error ? error.message : String(error),
+      rateLimitRemaining: apiError?.rateLimitRemaining,
+      rateLimitReset: apiError?.rateLimitReset,
+      retryAfter: apiError?.retryAfter,
     });
     return null;
   }

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -338,6 +338,81 @@ async function restSearchPage(
   };
 }
 
+/**
+ * Exact repo list beyond page 1 without paying for full PR pages: search
+ * cursors are deterministic (base64 "cursor:<offset>"), so pages 2..N fetch
+ * as aliases in ONE skinny request that selects only repository names.
+ * Returns null when unavailable (no token, or the request failed) — callers
+ * fall back to floor-with-"+" display.
+ */
+async function rawDeepRepoNames(
+  author: string,
+  pages: number
+): Promise<string[]> {
+  const q = `author:${author} type:pr is:public is:merged sort:created-desc`;
+  const aliases = Array.from({ length: pages - 1 }, (_, i) => {
+    const cursor = btoa(`cursor:${(i + 1) * 100}`);
+    return `p${i + 2}: search(query: $q, type: ISSUE, first: 100, after: "${cursor}") {
+      nodes { ... on PullRequest { repository { nameWithOwner } } }
+    }`;
+  }).join("\n");
+
+  const response = await fetch("https://api.github.com/graphql", {
+    method: "POST",
+    headers: githubHeaders(),
+    body: JSON.stringify({
+      query: `query($q: String!) { ${aliases} }`,
+      variables: { q },
+    }),
+    cache: "no-store",
+    signal: AbortSignal.timeout(8000),
+  });
+  const json = await response.json();
+  if (!response.ok || json.errors || !json.data) {
+    throw new GithubApiError(
+      json?.errors?.[0]?.message ?? json?.message ?? `GitHub HTTP ${response.status}`,
+      response.status,
+      response.headers.get("x-ratelimit-remaining"),
+      response.headers.get("x-ratelimit-reset"),
+      response.headers.get("retry-after")
+    );
+  }
+  const names = new Set<string>();
+  for (const key of Object.keys(json.data)) {
+    for (const node of json.data[key]?.nodes ?? []) {
+      if (node?.repository?.nameWithOwner) names.add(node.repository.nameWithOwner);
+    }
+  }
+  return [...names];
+}
+
+const cachedDeepRepoNames = unstable_cache(rawDeepRepoNames, ["gh-deep-repos"], {
+  revalidate: 3600,
+});
+
+export const getDeepRepoNames = async (
+  author: string,
+  totalCount: number
+): Promise<string[] | null> => {
+  if (!process.env.GITHUB_TOKEN) return null;
+  const pages = Math.min(Math.ceil(totalCount / 100), 10);
+  if (pages <= 1) return [];
+  try {
+    return await cachedDeepRepoNames(author, pages);
+  } catch (error) {
+    const apiError = error instanceof GithubApiError ? error : null;
+    reportGithubFailure({
+      source: "graphql-repo-breakdown",
+      status: apiError?.status ?? 0,
+      message: error instanceof Error ? error.message : String(error),
+      rateLimitRemaining: apiError?.rateLimitRemaining,
+      rateLimitReset: apiError?.rateLimitReset,
+      retryAfter: apiError?.retryAfter,
+    });
+    return null;
+  }
+};
+
 export const searchMergedPRs = async (
   author: string,
   cursor: string | null = null

--- a/lib/observability.ts
+++ b/lib/observability.ts
@@ -50,10 +50,19 @@ export function reportGithubFailure(input: {
   status: number;
   message?: string;
   headers?: Headers;
+  /** Direct rate fields for callers that can't pass Headers (cached scopes). */
+  rateLimitRemaining?: string | null;
+  rateLimitReset?: string | null;
+  retryAfter?: string | null;
 }) {
-  const remaining = input.headers?.get("x-ratelimit-remaining") ?? null;
-  const reset = input.headers?.get("x-ratelimit-reset") ?? null;
-  const retryAfter = input.headers?.get("retry-after") ?? null;
+  const remaining =
+    input.headers?.get("x-ratelimit-remaining") ??
+    input.rateLimitRemaining ??
+    null;
+  const reset =
+    input.headers?.get("x-ratelimit-reset") ?? input.rateLimitReset ?? null;
+  const retryAfter =
+    input.headers?.get("retry-after") ?? input.retryAfter ?? null;
   const reason = classifyGithubFailure(input.status, input.message, remaining);
 
   console.error(

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -2,6 +2,7 @@ import { cache } from "react";
 import { createClient } from "~/lib/supabase/server";
 import {
   getContributionCalendar,
+  getDeepRepoNames,
   getGitHubUserData,
   searchMergedPRs,
   type PRPageResult,
@@ -43,6 +44,19 @@ export const getProfileData = cache(async (username: string) => {
   ]);
 
   const userData = userResponse.data as GithubUser | null;
+
+  // Exact repo list without loading full PR pages (one skinny aliased
+  // request, ~1 point). Null = unknown; the client falls back to a floor.
+  let repoNames: string[] | null = null;
+  if (!firstPage.error) {
+    const page1Repos = firstPage.items.map((i) => i.repo);
+    if (firstPage.hasNext) {
+      const deep = await getDeepRepoNames(username, firstPage.totalCount);
+      repoNames = deep ? [...new Set([...page1Repos, ...deep])] : null;
+    } else {
+      repoNames = [...new Set(page1Repos)];
+    }
+  }
 
   let page: PRPageResult = firstPage;
   let loaded: ProfilePR[] = firstPage.items;
@@ -105,6 +119,7 @@ export const getProfileData = cache(async (username: string) => {
     // Where the client resumes loading deeper pages.
     endCursor: page.endCursor,
     hasNext: page.hasNext,
+    repoNames,
     excludedGitHubRepos,
     featuredPRUrls,
   };

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -1,19 +1,23 @@
 import { cache } from "react";
 import { createClient } from "~/lib/supabase/server";
 import {
-  getAllMergedPRs,
   getContributionCalendar,
-  getFirstMergedYear,
   getGitHubUserData,
+  searchMergedPRs,
+  type PRPageResult,
 } from "~/lib/github";
 import type { GithubUser, ProfilePR } from "~/types/shared";
 
+// Curated profiles may feature PRs deeper than page 1; walk until every
+// featured URL resolves. Bounded by search's own 1000-result ceiling.
+const MAX_FEATURED_WALK_PAGES = 10;
+
 /**
  * Loads everything needed to render a profile: the owner's curation row, the
- * GitHub profile, and the complete merged-PR history (search API caps at
- * 1000) partitioned into featured / non-featured after applying excluded
- * repos. Metadata (repo list, counts, "since") is exact from the first
- * render; the client windows the list for rendering, not for data.
+ * GitHub profile, and the first page (100) of merged PRs — one GraphQL
+ * request including the exact "since" year. Deeper pages stream to the
+ * client through /api/[username]/prs as the visitor scrolls; only profiles
+ * whose featured PRs sit past page 1 fetch further pages server-side.
  *
  * Wrapped in React `cache()` so `generateMetadata` and the page component
  * share a single execution per request.
@@ -28,75 +32,80 @@ export const getProfileData = cache(async (username: string) => {
 
   const row = rows?.[0];
   const excludedGitHubRepos: string[] = row?.excluded_github_repos ?? [];
-  const featuredGithubPRIds: string[] = row?.featured_github_prs ?? [];
+  // PR URLs (https://github.com/owner/repo/pull/N) — the one id both the
+  // GraphQL and REST engines agree on.
+  const featuredPRUrls: string[] = row?.featured_github_prs ?? [];
 
-  const [ghResponse, userResponse, sinceYear, contributionCalendar] =
-    await Promise.all([
-      getAllMergedPRs(username),
-      getGitHubUserData(username),
-      // Exact first-merged-PR year even past the search API's 1000-result cap.
-      getFirstMergedYear(username),
-      getContributionCalendar(username),
-    ]);
+  const [firstPage, userResponse, contributionCalendar] = await Promise.all([
+    searchMergedPRs(username),
+    getGitHubUserData(username),
+    getContributionCalendar(username),
+  ]);
 
-  const ghData = ghResponse.data;
   const userData = userResponse.data as GithubUser | null;
 
-  // Distinguish "no such user" (404) from a transient failure (rate-limit,
-  // network, timeout) so the page can show the right message.
-  const notFound = userResponse.status === 404;
-  const loadError =
-    (Boolean(userResponse.error) && userResponse.status !== 404) ||
-    (Boolean(ghResponse.error) && ghResponse.status !== 404);
-  const errorReason = loadError
-    ? (ghResponse.reason ?? userResponse.reason ?? "error")
-    : undefined;
-  const errorStatus = loadError
-    ? (ghResponse.error ? ghResponse.status : userResponse.status)
-    : undefined;
-
-  let items: ProfilePR[] = [];
-  let featuredPRs: ProfilePR[] = [];
-  let nonFeaturedPRs: ProfilePR[] = [];
-
-  if (ghData?.items?.length) {
-    items = ghData.items
-      .map((item) => ({
-        id: item.id,
-        title: item.title,
-        html_url: item.html_url,
-        repo: item.repository_url.slice(29),
-        merged_at: item.pull_request.merged_at,
-        reactions_count: item.reactions.total_count,
-        comments: item.comments,
-      }))
-      .filter((item) => !excludedGitHubRepos.includes(item.repo));
-    featuredPRs = items
-      .filter((item) => featuredGithubPRIds.includes(item.id.toString()))
-      .sort(
-        (a, b) =>
-          featuredGithubPRIds.indexOf(a.id.toString()) -
-          featuredGithubPRIds.indexOf(b.id.toString())
-      );
-    nonFeaturedPRs = items.filter(
-      (item) => !featuredGithubPRIds.includes(item.id.toString())
-    );
+  let page: PRPageResult = firstPage;
+  let loaded: ProfilePR[] = firstPage.items;
+  if (featuredPRUrls.length) {
+    const resolved = new Set(loaded.map((i) => i.html_url));
+    let walked = 1;
+    while (
+      page.hasNext &&
+      page.endCursor &&
+      walked < MAX_FEATURED_WALK_PAGES &&
+      !featuredPRUrls.every((url) => resolved.has(url))
+    ) {
+      page = await searchMergedPRs(username, page.endCursor);
+      if (page.error) break;
+      loaded = [...loaded, ...page.items];
+      page.items.forEach((i) => resolved.add(i.html_url));
+      walked += 1;
+    }
   }
+
+  // Distinguish "no such user" (404) from a transient failure (rate-limit,
+  // network, timeout) so the page can show the right message. A search
+  // failure with a healthy user is degraded, not dead: identity and the
+  // contribution graph still render while the PR list retries client-side.
+  const notFound = userResponse.status === 404;
+  const searchFailed = Boolean(firstPage.error);
+  const loadError = Boolean(userResponse.error) && userResponse.status !== 404;
+  const prsDegraded = !loadError && !notFound && searchFailed;
+  const errorReason =
+    loadError || prsDegraded
+      ? (firstPage.reason ?? userResponse.reason ?? "error")
+      : undefined;
+
+  const items = loaded.filter(
+    (item) => !excludedGitHubRepos.includes(item.repo)
+  );
+  const featuredPRs = items
+    .filter((item) => featuredPRUrls.includes(item.html_url))
+    .sort(
+      (a, b) =>
+        featuredPRUrls.indexOf(a.html_url) - featuredPRUrls.indexOf(b.html_url)
+    );
+  const nonFeaturedPRs = items.filter(
+    (item) => !featuredPRUrls.includes(item.html_url)
+  );
 
   return {
     ownerRowId: row?.id as string | undefined,
     userData,
     notFound,
     loadError,
+    prsDegraded,
     errorReason,
-    errorStatus,
-    totalCount: ghData?.total_count ?? 0,
-    sinceYear,
+    totalCount: firstPage.totalCount,
+    sinceYear: firstPage.sinceYear,
     contributionCalendar,
     items,
     featuredPRs,
     nonFeaturedPRs,
+    // Where the client resumes loading deeper pages.
+    endCursor: page.endCursor,
+    hasNext: page.hasNext,
     excludedGitHubRepos,
-    featuredGithubPRIds,
+    featuredPRUrls,
   };
 });

--- a/scripts/migrate-featured-to-urls.py
+++ b/scripts/migrate-featured-to-urls.py
@@ -28,9 +28,8 @@ LOCAL_DB = ["docker", "exec", "supabase_db_my-pr", "psql", "-U", "postgres", "-d
 
 def run_sql(target: str, query: str):
     if target == "local":
-        env = {**os.environ, "PGPASSWORD": "postgres"}
         out = subprocess.run(
-            LOCAL_DB + ["-c", query], capture_output=True, text=True, env=env
+            LOCAL_DB + ["-c", query], capture_output=True, text=True
         )
         if out.returncode != 0:
             raise RuntimeError(out.stderr)

--- a/scripts/migrate-featured-to-urls.py
+++ b/scripts/migrate-featured-to-urls.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""One-off: translate featured_github_prs from REST issue ids to PR URLs.
+
+The KIS-185 GraphQL engine can't see REST issue ids (GraphQL exposes the PR
+database id, a different table), so curation is re-keyed to the PR URL —
+the identifier both APIs return verbatim.
+
+Usage:
+  GITHUB_TOKEN=... python3 scripts/migrate-featured-to-urls.py local
+  GITHUB_TOKEN=... SUPABASE_ACCESS_TOKEN=... python3 scripts/migrate-featured-to-urls.py prod
+
+Idempotent: values already shaped like PR URLs pass through untouched.
+Unmappable ids (PR gone from search, or past the 1000-result cap) are
+dropped with a report line — they could never render again anyway.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.parse
+import urllib.request
+
+PROD_PROJECT_REF = "fwaikexukvjlfudvyrgk"
+LOCAL_DB = ["docker", "exec", "supabase_db_my-pr", "psql", "-U", "postgres", "-d", "postgres", "-tA"]
+
+
+def run_sql(target: str, query: str):
+    if target == "local":
+        env = {**os.environ, "PGPASSWORD": "postgres"}
+        out = subprocess.run(
+            LOCAL_DB + ["-c", query], capture_output=True, text=True, env=env
+        )
+        if out.returncode != 0:
+            raise RuntimeError(out.stderr)
+        return out.stdout.strip()
+    token = os.environ["SUPABASE_ACCESS_TOKEN"]
+    req = urllib.request.Request(
+        f"https://api.supabase.com/v1/projects/{PROD_PROJECT_REF}/database/query",
+        data=json.dumps({"query": query}).encode(),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "content-type": "application/json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as res:
+        return json.loads(res.read())
+
+
+def fetch_pr_url_map(username: str) -> dict[str, str]:
+    """REST search: issue id -> html_url for the user's merged PRs."""
+    token = os.environ["GITHUB_TOKEN"]
+    mapping: dict[str, str] = {}
+    for page in range(1, 11):
+        q = urllib.parse.quote(f"author:{username} type:pr is:public is:merged")
+        req = urllib.request.Request(
+            f"https://api.github.com/search/issues?q={q}&per_page=100&page={page}",
+            headers={"Authorization": f"Bearer {token}", "User-Agent": "myprs-migration"},
+        )
+        with urllib.request.urlopen(req) as res:
+            data = json.loads(res.read())
+        for item in data.get("items", []):
+            mapping[str(item["id"])] = item["html_url"]
+        if page * 100 >= min(data.get("total_count", 0), 1000):
+            break
+        time.sleep(2.5)  # stay under the 30/min search pool
+    return mapping
+
+
+def get_rows(target: str):
+    query = (
+        "select github_username, featured_github_prs from users "
+        "where featured_github_prs is not null and array_length(featured_github_prs,1) > 0"
+    )
+    if target == "local":
+        out = run_sql(
+            target,
+            "select json_agg(json_build_object('github_username', github_username, "
+            "'featured_github_prs', featured_github_prs)) from users "
+            "where featured_github_prs is not null and array_length(featured_github_prs,1) > 0",
+        )
+        return json.loads(out) if out else []
+    return run_sql(target, query)
+
+
+def update_row(target: str, username: str, urls: list[str]):
+    array_sql = "array[" + ",".join("'" + u.replace("'", "''") + "'" for u in urls) + "]::text[]"
+    if not urls:
+        array_sql = "array[]::text[]"
+    query = (
+        f"update users set featured_github_prs = {array_sql} "
+        f"where github_username = '{username}'"
+    )
+    run_sql(target, query)
+
+
+def main():
+    target = sys.argv[1] if len(sys.argv) > 1 else ""
+    if target not in ("local", "prod"):
+        sys.exit("usage: migrate-featured-to-urls.py local|prod")
+
+    rows = get_rows(target)
+    print(f"{len(rows)} user(s) with featured PRs on {target}")
+    for row in rows:
+        username = row["github_username"]
+        current = row["featured_github_prs"]
+        if all(v.startswith("https://github.com/") for v in current):
+            print(f"  {username}: already migrated ({len(current)} urls)")
+            continue
+        mapping = fetch_pr_url_map(username)
+        translated, dropped = [], []
+        for value in current:
+            if value.startswith("https://github.com/"):
+                translated.append(value)
+            elif value in mapping:
+                translated.append(mapping[value])
+            else:
+                dropped.append(value)
+        update_row(target, username, translated)
+        note = f", dropped {dropped}" if dropped else ""
+        print(f"  {username}: {len(current)} ids -> {len(translated)} urls{note}")
+        time.sleep(2.5)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/pr-actions.ts
+++ b/utils/pr-actions.ts
@@ -3,10 +3,15 @@
 import { revalidatePath } from "next/cache";
 import { createClient } from "~/lib/supabase/server";
 
+// featured_github_prs stores canonical PR URLs — the only identifier the
+// REST and GraphQL search engines agree on (their numeric ids differ).
+const PR_URL = /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+$/;
+
 export async function toggleFeaturedAction(input: {
-  prId: string;
+  prUrl: string;
   username: string;
 }) {
+  if (!PR_URL.test(input.prUrl)) return { error: "Invalid PR" };
   const supabase = await createClient();
   const {
     data: { user },
@@ -26,9 +31,9 @@ export async function toggleFeaturedAction(input: {
   }
 
   const current: string[] = row?.featured_github_prs ?? [];
-  const updated = current.includes(input.prId)
-    ? current.filter((id) => id !== input.prId)
-    : [...current, input.prId];
+  const updated = current.includes(input.prUrl)
+    ? current.filter((url) => url !== input.prUrl)
+    : [...current, input.prUrl];
 
   const { error } = await supabase
     .from("users")
@@ -70,8 +75,11 @@ export async function saveExcludedReposAction(input: {
  */
 export async function reorderFeaturedAction(input: {
   username: string;
-  orderedIds: string[];
+  orderedUrls: string[];
 }) {
+  if (!input.orderedUrls.every((url) => PR_URL.test(url))) {
+    return { error: "Invalid PR" };
+  }
   const supabase = await createClient();
   const {
     data: { user },
@@ -91,17 +99,17 @@ export async function reorderFeaturedAction(input: {
   // featured if their repo is un-excluded later.
   const current: string[] = row?.featured_github_prs ?? [];
   const currentSet = new Set(current);
-  const orderedSet = new Set(input.orderedIds);
+  const orderedSet = new Set(input.orderedUrls);
   const valid =
-    orderedSet.size === input.orderedIds.length &&
-    input.orderedIds.every((id) => currentSet.has(id));
+    orderedSet.size === input.orderedUrls.length &&
+    input.orderedUrls.every((url) => currentSet.has(url));
   if (!valid) {
     return { error: "Order is out of date — refresh and try again" };
   }
 
   const next = [
-    ...input.orderedIds,
-    ...current.filter((id) => !orderedSet.has(id)),
+    ...input.orderedUrls,
+    ...current.filter((url) => !orderedSet.has(url)),
   ];
   const { error } = await supabase
     .from("users")


### PR DESCRIPTION
Cold profiles cost up to 11 REST search calls against a 30 req/min pool. This makes it ~2 GraphQL points of a 5,000/hr pool.

- GraphQL search as the primary engine; page 1 + since-year probe batched in one request. REST stays as the tokenless fallback.
- Deeper history pages stream through /api/[username]/prs on scroll; server walks extra pages only when featured PRs sit past page 1.
- Featured re-keyed from REST issue ids to PR URLs (the engines' numeric ids are different tables). scripts/migrate-featured-to-urls.py migrates existing rows — run against prod immediately after deploy.
- Graceful degrade on rate limit: identity + contribution graph render with an auto-retrying PR-list placeholder.
- Exact repo counts/filter restored via one skinny aliased request (search cursors are deterministic).
- Contribution calendar was never actually cached (POST fetches skip the data cache) — now wrapped in unstable_cache. Verified: three views, one fetch.

Verification details in Linear KIS-185. Deploy sequence: merge → backup featured rows → run migration → verify.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paginated loading of merged pull requests as users scroll.
  * Added retry messaging and automatic recovery for rate-limited or unavailable pull request data.
  * Improved profile statistics and loading states, including approximate repository counts when needed.
  * Featured pull requests now use canonical GitHub URLs for reliable selection and reordering.
* **Bug Fixes**
  * Improved handling of GitHub failures, caching, and rate-limit reporting.
  * Prevented duplicate pull requests and excluded repositories from profile results as configured.
* **Chores**
  * Added migration support for converting existing featured pull requests to URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->