### PR TITLE
fix: PR review findings — cache-poisoning edges, bounded retry, preview fidelity

### DIFF
--- a/app/[username]/PRRetry.tsx
+++ b/app/[username]/PRRetry.tsx
@@ -10,6 +10,7 @@ import posthog from "posthog-js";
 // refresh re-renders the full page.
 const BASE_DELAY_MS = 8000;
 const MAX_DELAY_MS = 30000;
+const MAX_ATTEMPTS = 10;
 
 export default function PRRetry({
   username,
@@ -27,6 +28,7 @@ export default function PRRetry({
   }, [username]);
 
   React.useEffect(() => {
+    if (attempt >= MAX_ATTEMPTS) return;
     let cancelled = false;
     const delay =
       Math.min(BASE_DELAY_MS * (attempt + 1), MAX_DELAY_MS) +
@@ -61,9 +63,11 @@ export default function PRRetry({
         className="rail-line absolute bottom-2 left-3 top-0 w-[2px] rounded-full bg-zinc-200 dark:bg-zinc-800"
       />
       <p className="font-mono relative pl-10 text-sm text-zinc-500 dark:text-zinc-400">
-        {reason === "rate_limited"
-          ? "GitHub is rate-limiting us right now — the pull requests will load automatically in a moment."
-          : "GitHub isn't answering right now — retrying automatically."}
+        {attempt >= MAX_ATTEMPTS
+          ? "GitHub still isn't answering — reload the page to try again."
+          : reason === "rate_limited"
+            ? "GitHub is rate-limiting us right now — the pull requests will load automatically in a moment."
+            : "GitHub isn't answering right now — retrying automatically."}
       </p>
     </div>
   );

--- a/app/[username]/PRSections.tsx
+++ b/app/[username]/PRSections.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { AnimatePresence, motion, Reorder } from "framer-motion";
 import Link from "next/link";
 import posthog from "posthog-js";
-import { useSession } from "~/app/providers";
+import { useSession, useVisitorPreview } from "~/app/providers";
 import { DemoGithub } from "~/components/custom/GithubCard";
 import PRFilter from "~/components/custom/PRFilter";
 import {
@@ -53,7 +53,8 @@ export default function PRSections({
   const isActualOwner = Boolean(
     ownerRowId && session?.user?.id && session.user.id === ownerRowId
   );
-  const [previewVisitor, setPreviewVisitor] = React.useState(false);
+  const { previewing: previewVisitor, setPreviewing: setPreviewVisitor } =
+    useVisitorPreview();
   const isOwner = isActualOwner && !previewVisitor;
   const sentinelRef = React.useRef<HTMLLIElement>(null);
   const [deeperPRs, setDeeperPRs] = React.useState<ProfilePR[]>([]);
@@ -220,13 +221,12 @@ export default function PRSections({
     const observer = new IntersectionObserver(
       (entries) => {
         if (!entries[0].isIntersecting) return;
-        setVisible((v) => {
-          posthog.capture("list_extended", {
-            profile: username,
-            shown_after: v + WINDOW_STEP,
-          });
-          return v + WINDOW_STEP;
+        // capture outside the updater — React may invoke updaters twice
+        posthog.capture("list_extended", {
+          profile: username,
+          shown_after: visible + WINDOW_STEP,
         });
+        setVisible((v) => v + WINDOW_STEP);
         // Keep the data ahead of the window.
         if (visible + WINDOW_STEP >= displayRest.length) void loadDeeperPage();
       },

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { connection } from "next/server";
 import { getProfileData } from "~/lib/profile";
 import ContributionGraph from "~/components/custom/ContributionGraph";
 import OwnerGate from "~/components/custom/OwnerGate";
@@ -67,6 +68,10 @@ export default async function ProfilePage({
     repoNames,
     ownerRowId,
   } = await getProfileData(username);
+
+  // A transient failure must never become the cached shell for an hour —
+  // degrade dynamically; the first healthy render becomes the shell.
+  if (loadError || prsDegraded) await connection();
 
   if (loadError && !userData) {
     return (
@@ -168,7 +173,7 @@ export default async function ProfilePage({
 
       {prsDegraded ? (
         <PRRetry username={username} reason={errorReason ?? "error"} />
-      ) : items.length ? (
+      ) : items.length || hasNext ? (
         <PRSections
           featuredPRs={featuredPRs}
           nonFeaturedPRs={nonFeaturedPRs}

--- a/app/api/[username]/og/route.tsx
+++ b/app/api/[username]/og/route.tsx
@@ -41,6 +41,8 @@ export async function GET(
     getGitHubUserData(username),
   ]);
 
+  // Never bake a transient failure into a cached social card.
+  const searchFailed = Boolean(prs.error);
   const total = prs.totalCount;
   const page1Repos = [...new Set(prs.items.map((i) => i.repo))];
   const deep = prs.hasNext ? await getDeepRepoNames(username, total) : [];
@@ -59,11 +61,13 @@ export async function GET(
   const handleLine = `@${username}`;
   const urlLine = `myprs.dev/${username}`;
 
-  const stats: Array<[string, string]> = [
-    [String(total), "merged PRs"],
-    ...(repoCount ? [[repos, "repositories"] as [string, string]] : []),
-    ...(since ? [[String(since), "since"] as [string, string]] : []),
-  ];
+  const stats: Array<[string, string]> = searchFailed
+    ? []
+    : [
+        [String(total), "merged PRs"],
+        ...(repoCount ? [[repos, "repositories"] as [string, string]] : []),
+        ...(since ? [[String(since), "since"] as [string, string]] : []),
+      ];
 
   const statBlock = ([value, label]: [string, string]) => (
     <div
@@ -204,7 +208,9 @@ export async function GET(
         { name: "Geist Mono", data: geistMono, weight: 400 },
       ],
       headers: {
-        "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+        "Cache-Control": searchFailed
+          ? "no-store"
+          : "public, s-maxage=3600, stale-while-revalidate=86400",
       },
     }
   );

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,3 +1,4 @@
+import { updateTag } from "next/cache";
 import { NextResponse } from "next/server";
 import { createClient } from "~/lib/supabase/server";
 
@@ -36,6 +37,13 @@ export async function GET(request: Request) {
       return NextResponse.redirect(new URL("/?error=auth", url.origin));
     }
     const githubUsername = data.user?.user_metadata?.user_name;
+
+    if (githubUsername) {
+      // A profile viewed before its owner ever signed in cached a missing
+      // curation row (no ownerRowId) — without this purge the owner could
+      // not curate for up to an hour after their first login.
+      updateTag(`curation-${githubUsername}`);
+    }
 
     if ((!redirectUrl || redirectUrl === "/") && githubUsername) {
       redirectUrl = `/${githubUsername}`;

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -26,6 +26,17 @@ export function useSession() {
   return React.useContext(SessionContext);
 }
 
+// "View as visitor" preview — shared so every owner affordance (share,
+// curate, filter) hides together, not just the PR sections.
+const VisitorPreviewContext = React.createContext<{
+  previewing: boolean;
+  setPreviewing: (v: boolean) => void;
+}>({ previewing: false, setPreviewing: () => {} });
+
+export function useVisitorPreview() {
+  return React.useContext(VisitorPreviewContext);
+}
+
 // usePathname is request-dependent, which would block the static shell if
 // called in Providers itself; isolated here it streams in after prerender.
 function PageViewTracker({ ready }: { ready: boolean }) {
@@ -43,6 +54,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
     undefined
   );
   const [posthogLoaded, setPosthogLoaded] = React.useState(false);
+  const [previewing, setPreviewing] = React.useState(false);
   const hadSessionRef = React.useRef(false);
 
   // Initialize PostHog once on the client.
@@ -104,10 +116,12 @@ export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <SupabaseContext.Provider value={supabase}>
       <SessionContext.Provider value={session}>
-        <Suspense fallback={null}>
-          <PageViewTracker ready={posthogLoaded} />
-        </Suspense>
-        {children}
+        <VisitorPreviewContext.Provider value={{ previewing, setPreviewing }}>
+          <Suspense fallback={null}>
+            <PageViewTracker ready={posthogLoaded} />
+          </Suspense>
+          {children}
+        </VisitorPreviewContext.Provider>
       </SessionContext.Provider>
     </SupabaseContext.Provider>
   );

--- a/components/custom/OwnerGate.tsx
+++ b/components/custom/OwnerGate.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useSession } from "~/app/providers";
+import { useSession, useVisitorPreview } from "~/app/providers";
 
 // The static shell renders the visitor view for everyone; owner-only
 // affordances mount here once the client session proves ownership.
@@ -12,8 +12,9 @@ export default function OwnerGate({
   children: React.ReactNode;
 }) {
   const session = useSession();
+  const { previewing } = useVisitorPreview();
   const isOwner = Boolean(
     ownerRowId && session?.user?.id && session.user.id === ownerRowId
   );
-  return isOwner ? <>{children}</> : null;
+  return isOwner && !previewing ? <>{children}</> : null;
 }

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -83,8 +83,11 @@ export const getProfileData = cache(async (username: string) => {
       walked < MAX_FEATURED_WALK_PAGES &&
       !featuredPRUrls.every((url) => resolved.has(url))
     ) {
-      page = await searchMergedPRs(username, page.endCursor);
-      if (page.error) break;
+      // A transient failure must not clobber the last good cursor — the
+      // client resumes deep-loading from wherever the walk stopped.
+      const next = await searchMergedPRs(username, page.endCursor);
+      if (next.error) break;
+      page = next;
       loaded = [...loaded, ...page.items];
       page.items.forEach((i) => resolved.add(i.html_url));
       walked += 1;


### PR DESCRIPTION
Stacked on #16. Addresses the real findings from the bot reviews on #15/#16:

- Auth callback purges the curation tag on login — a profile viewed before its owner ever signed in cached the missing row, locking the owner out of curation for up to an hour (Codex P1)
- Degraded/error renders call connection() so a transient GitHub failure never becomes the 1h cached shell
- OG route drops stat blocks + no-store on search failure instead of caching "0 merged PRs" into social CDNs
- Profiles whose entire first page is excluded still mount pagination (deeper PRs stay reachable)
- Featured walk keeps the last good cursor on transient failure
- list_extended captured outside the state updater; PRRetry capped at 10 attempts
- "View as visitor" now hides ALL owner affordances (shared context), including share

Deferred as noise: sentinel re-observe churn (behavior is intended viewport-fill), cross-page merged-order drift (cosmetic, rare), stale analytics comment (already fixed in an earlier commit).