### PR TITLE
feat: warm the profile cache at login, land on the homepage

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,5 +1,5 @@
 import { revalidateTag } from "next/cache";
-import { NextResponse } from "next/server";
+import { NextResponse, after } from "next/server";
 import { createClient } from "~/lib/supabase/server";
 
 // Prevents an open redirect via the `redirectTo` param. Resolve the value
@@ -26,8 +26,9 @@ export async function GET(request: Request) {
   const code = url.searchParams.get("code");
   const redirectTo = url.searchParams.get("redirectTo");
   // A real deep path (e.g. the profile being viewed at login) is preserved;
-  // homepage, "false", or absent falls through to the user's own profile.
-  let redirectUrl = safeRelativePath(redirectTo, url.origin);
+  // otherwise land on the instant homepage while the profile warms behind
+  // (the "Continue as" link there is prefetched and will be warm on click).
+  const redirectUrl = safeRelativePath(redirectTo, url.origin);
 
   if (code) {
     const supabase = await createClient();
@@ -45,10 +46,20 @@ export async function GET(request: Request) {
       // Server-Action-only; revalidateTag is the Route Handler equivalent
       // (SWR semantics: at worst one stale render right after login).
       revalidateTag(`curation-${githubUsername}`, "max");
-    }
 
-    if ((!redirectUrl || redirectUrl === "/") && githubUsername) {
-      redirectUrl = `/${githubUsername}`;
+      // Warm the profile while they read the homepage: a real self-fetch
+      // through the normal render path fills the use-cache-remote entries
+      // AND the cached shell, starting the 5-14s cold fill at the earliest
+      // possible moment. after() runs once the redirect is sent.
+      const profileUrl = new URL(`/${githubUsername}`, url.origin);
+      after(async () => {
+        try {
+          await fetch(profileUrl, { cache: "no-store" });
+          console.log(`login warm completed for ${githubUsername}`);
+        } catch (error) {
+          console.error("login warm failed:", error);
+        }
+      });
     }
   }
 


### PR DESCRIPTION
First-login profile visits hit the cold fill (5–14s, progressive since #20 but still slow). This starts that fill at the earliest possible moment instead:

- Auth callback fires a fire-and-forget self-fetch of the user's profile inside after() — a real request through the normal render path, so it warms both the use-cache-remote entries and the cached shell while they read the homepage
- Default post-login landing changes from own-profile to the homepage (instant static). Deep-path redirects still return where they logged in from. The homepage "Continue as" link already prefetches, so the profile is typically warm on click
- Verified: redirect matrix (default → /, deep path preserved, open-redirect still blocked), build keeps partial prerender. The warm itself needs a real OAuth exchange — verify post-deploy via "login warm completed" in the function logs on next login

Behavior change, by design: reverts the earlier "land on own profile after login" default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-login redirect handling by allowing only validated relative paths.
  * Redirects to the homepage when a safe destination is not provided.
  * Added background profile loading after successful authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->