### PR TITLE
feat: cold-load crunching animation for the PR rail

### DIFF
--- a/app/[username]/sections.tsx
+++ b/app/[username]/sections.tsx
@@ -268,17 +268,52 @@ export function GraphSkeleton() {
   );
 }
 
+// Cold fills take seconds — this is the rare/first-time tier, so it earns
+// a real loading story instead of a mute pulse: nodes land on the trunk
+// like commits while status lines narrate the actual pipeline. Pure CSS,
+// so it runs before hydration and in throttled tabs.
+const CRUNCH_STEPS = [
+  "searching GitHub for merged pull requests…",
+  "scanning repositories…",
+  "resolving the first merged year…",
+  "drawing the rail…",
+];
+
 export function RailSkeleton() {
   return (
-    <div aria-hidden className="animate-pulse motion-reduce:animate-none">
-      <div className="mt-5 h-[13px] w-80 rounded bg-zinc-100 dark:bg-zinc-800/60" />
+    <div aria-hidden>
+      <div className="crunch-status font-mono mt-5 h-[13px] text-[13px] text-zinc-500 dark:text-zinc-400 motion-reduce:hidden">
+        {CRUNCH_STEPS.map((step, i) => (
+          <span
+            key={step}
+            className="crunch-line"
+            style={{ "--i": i } as CSSProperties}
+          >
+            {step}
+          </span>
+        ))}
+      </div>
+      <p className="font-mono mt-5 hidden h-[13px] text-[13px] text-zinc-500 motion-reduce:block dark:text-zinc-400">
+        crunching the data…
+      </p>
       <div className="relative mt-10">
         <span className="absolute bottom-2 left-3 top-0 w-[2px] rounded-full bg-zinc-200 dark:bg-zinc-800" />
         <ul>
           {[0, 1, 2, 3, 4].map((i) => (
             <li key={i} className="relative py-2 pl-10">
-              <div className="h-[15px] w-3/4 rounded bg-zinc-100 dark:bg-zinc-800/60" />
-              <div className="mt-2 h-[12px] w-48 rounded bg-zinc-100 dark:bg-zinc-800/60" />
+              {/* ghost node: lights up when its "commit" lands */}
+              <span
+                className="crunch-node absolute left-[7px] top-[16px] h-[11px] w-[11px] rounded-full border-2 border-zinc-300 bg-[#fdfafa] dark:border-zinc-700 dark:bg-[#191919]"
+                style={{ "--i": i } as CSSProperties}
+              />
+              <span
+                className="crunch-connector absolute left-[18px] top-[21px] h-px w-[14px] bg-zinc-200 dark:bg-zinc-800"
+                style={{ "--i": i } as CSSProperties}
+              />
+              <div className="crunch-row" style={{ "--i": i } as CSSProperties}>
+                <div className="h-[15px] w-3/4 rounded bg-zinc-100 dark:bg-zinc-800/60" />
+                <div className="mt-2 h-[12px] w-48 rounded bg-zinc-100 dark:bg-zinc-800/60" />
+              </div>
             </li>
           ))}
         </ul>

--- a/app/globals.css
+++ b/app/globals.css
@@ -284,3 +284,90 @@
   animation-duration: 280ms;
   animation-timing-function: ease;
 }
+
+/* Cold-load "crunching" state: nodes land on the trunk like commits while
+   status lines narrate the pipeline. Rare-tier frequency (first visitor per
+   profile per hour), so the loop earns its place; reduced-motion swaps to a
+   static line via motion-reduce classes in the markup. */
+.crunch-status {
+  position: relative;
+}
+.crunch-line {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  animation: crunch-line 10s linear infinite;
+  animation-delay: calc(var(--i) * 2.5s);
+}
+@keyframes crunch-line {
+  0% {
+    opacity: 0;
+    transform: translateY(3px);
+  }
+  3%,
+  22% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  25%,
+  100% {
+    opacity: 0;
+    transform: translateY(-3px);
+  }
+}
+.crunch-node {
+  animation: crunch-node 2.4s cubic-bezier(0.23, 1, 0.32, 1) infinite;
+  animation-delay: calc(var(--i) * 0.36s);
+}
+@keyframes crunch-node {
+  0%,
+  55% {
+    border-color: var(--crunch-node-idle, #d4d4d8);
+    background-color: transparent;
+    transform: scale(1);
+  }
+  62% {
+    transform: scale(1.25);
+  }
+  70%,
+  85% {
+    border-color: var(--crunch-node-lit, #18181b);
+    background-color: var(--crunch-node-lit, #18181b);
+    transform: scale(1);
+  }
+  100% {
+    border-color: var(--crunch-node-idle, #d4d4d8);
+    background-color: transparent;
+  }
+}
+.dark .crunch-node {
+  --crunch-node-idle: #3f3f46;
+  --crunch-node-lit: #fafafa;
+}
+.crunch-connector,
+.crunch-row {
+  opacity: 0.55;
+  animation: crunch-row 2.4s ease-out infinite;
+  animation-delay: calc(var(--i) * 0.36s);
+}
+@keyframes crunch-row {
+  0%,
+  55% {
+    opacity: 0.55;
+  }
+  70%,
+  85% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.55;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .crunch-line,
+  .crunch-node,
+  .crunch-connector,
+  .crunch-row {
+    animation: none;
+  }
+}

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -590,7 +590,10 @@ async function cachedContributionCalendar(
   username: string
 ): Promise<ContributionCalendar | null> {
   "use cache: remote";
-  cacheLife("hours");
+  // Contributions tolerate a day of staleness (today's square may lag);
+  // in exchange the hourly shell rebuild almost always finds this warm,
+  // so the graph lands with the identity instead of ~1s later.
+  cacheLife("days");
   cacheTag(`profile-${username}`);
   return rawContributionCalendar(username);
 }


### PR DESCRIPTION
The 6–14s cold fill showed a mute pulse skeleton. Now: ghost nodes on the trunk light up in sequence (commits landing) while mono status lines cycle through the real pipeline — searching PRs, scanning repositories, resolving the first merged year, drawing the rail.

- Pure CSS (transform/opacity keyframes) — works before hydration and in throttled tabs
- prefers-reduced-motion: static "crunching the data…" line, no loops
- Identical layout footprint to the old skeleton — no shift when content lands
- Only shows on the rare tier (cold fills); warm loads never see it

Verified on a prod build with a cold profile: status line + 5 ghost nodes mid-fill (screenshot in Linear), rail replaces it cleanly, no residue.